### PR TITLE
Expose SetYPerpendicular detection parameter

### DIFF
--- a/src/Bonsai.Aruco/DetectMarkers.cs
+++ b/src/Bonsai.Aruco/DetectMarkers.cs
@@ -20,6 +20,7 @@ namespace Bonsai.Aruco
             ThresholdMethod = ThresholdMethod.AdaptiveThreshold;
             CornerRefinement = CornerRefinementMethod.Lines;
             MarkerSize = 10;
+            SetYPerpendicular = false;
         }
 
         [FileNameFilter("YAML Files (*.yml)|*.yml|All Files (*.*)|*.*")]
@@ -47,6 +48,8 @@ namespace Bonsai.Aruco
 
         [Description("The size of the marker sides, in meters.")]
         public float MarkerSize { get; set; }
+        [Description("Whether to set Y as the normal axis of the marker, otherwise Z is used as normal axis.")]
+        public bool SetYPerpendicular { get; set; }
 
         public override IObservable<MarkerFrame> Process(IObservable<IplImage> source)
         {
@@ -82,7 +85,7 @@ namespace Bonsai.Aruco
                         detector.MaxSize = MaxSize;
                         detector.CornerRefinement = CornerRefinement;
 
-                        var detectedMarkers = detector.Detect(input, cameraMatrix, distortion, MarkerSize);
+                        var detectedMarkers = detector.Detect(input, cameraMatrix, distortion, MarkerSize, SetYPerpendicular);
                         return new MarkerFrame(parameters, detectedMarkers);
                     });
                 });

--- a/src/Bonsai.Aruco/DetectMarkers.cs
+++ b/src/Bonsai.Aruco/DetectMarkers.cs
@@ -48,7 +48,7 @@ namespace Bonsai.Aruco
         [Description("The size of the marker sides, in meters.")]
         public float MarkerSize { get; set; }
 
-        [Description("Whether to set Y as the normal axis of the marker, otherwise Z is used as normal axis.")]
+        [Description("True to use the Y axis as the marker normal; otherwise the Z axis is used.")]
         public bool SetYPerpendicular { get; set; }
 
         public override IObservable<MarkerFrame> Process(IObservable<IplImage> source)

--- a/src/Bonsai.Aruco/DetectMarkers.cs
+++ b/src/Bonsai.Aruco/DetectMarkers.cs
@@ -20,7 +20,6 @@ namespace Bonsai.Aruco
             ThresholdMethod = ThresholdMethod.AdaptiveThreshold;
             CornerRefinement = CornerRefinementMethod.Lines;
             MarkerSize = 10;
-            SetYPerpendicular = false;
         }
 
         [FileNameFilter("YAML Files (*.yml)|*.yml|All Files (*.*)|*.*")]
@@ -48,6 +47,7 @@ namespace Bonsai.Aruco
 
         [Description("The size of the marker sides, in meters.")]
         public float MarkerSize { get; set; }
+
         [Description("Whether to set Y as the normal axis of the marker, otherwise Z is used as normal axis.")]
         public bool SetYPerpendicular { get; set; }
 


### PR DESCRIPTION
When drawing a 3D cube in the `DetectMarkers` visualizer on a tracked marker, the cube was rotated such that its up-axis lay in the marker plane rather than perpendicular to it. The root cause is that the underlying `MarkerDetector.Detect` defaults `setYPerpendicular` to `true`, making the Y axis the marker normal while most renderers expect Z.

This PR adds a `SetYPerpendicular` property on `DetectMarkers` that forwards to the `Detect` overload accepting this parameter. The new property defaults to `false`, so the Z axis is used as the marker normal out of the box. With this change, the 3D cube is drawn correctly.

Note that this flips the effective default of `DetectMarkers` relative to the prior release, which implicitly relied on the Aruco default of `true`. Workflows that depended on Y being the marker normal will need to set `SetYPerpendicular` to `true` explicitly.