### PR TITLE
Add XML documentation for public API

### DIFF
--- a/src/Bonsai.Aruco.Design/DetectMarkersVisualizer.cs
+++ b/src/Bonsai.Aruco.Design/DetectMarkersVisualizer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Bonsai.Design;
 using Bonsai.Vision.Design;
@@ -16,6 +16,14 @@ using System.Windows.Forms;
 
 namespace Bonsai.Aruco.Design
 {
+    /// <summary>
+    /// Provides a type visualizer that overlays detected markers on the image processed
+    /// by a <see cref="DetectMarkers"/> operator.
+    /// </summary>
+    /// <remarks>
+    /// Right-clicking the visualizer canvas toggles between displaying the original image
+    /// and the thresholded image used for marker detection.
+    /// </remarks>
     public class DetectMarkersVisualizer : IplImageVisualizer
     {
         IplImage input;
@@ -24,6 +32,7 @@ namespace Bonsai.Aruco.Design
         MarkerDetector imageThreshold;
         DetectMarkers detectMarkers;
 
+        /// <inheritdoc/>
         public override void Show(object value)
         {
             if (input != null)
@@ -62,6 +71,7 @@ namespace Bonsai.Aruco.Design
             }
         }
 
+        /// <inheritdoc/>
         public override void Load(IServiceProvider provider)
         {
             showThreshold = false;
@@ -91,6 +101,7 @@ namespace Bonsai.Aruco.Design
             };
         }
 
+        /// <inheritdoc/>
         public override void Unload()
         {
             if (inputObserver != null)

--- a/src/Bonsai.Aruco.Design/MarkerOverlay.cs
+++ b/src/Bonsai.Aruco.Design/MarkerOverlay.cs
@@ -1,4 +1,4 @@
-﻿using Aruco.Net;
+using Aruco.Net;
 using Bonsai;
 using Bonsai.Aruco.Design;
 using Bonsai.Design;
@@ -10,10 +10,14 @@ using System;
 
 namespace Bonsai.Aruco.Design
 {
+    /// <summary>
+    /// Provides a type visualizer that overlays a marker over an existing image visualizer.
+    /// </summary>
     public class MarkerOverlay : DialogTypeVisualizer
     {
         IplImageVisualizer visualizer;
 
+        /// <inheritdoc/>
         public override void Show(object value)
         {
             var marker = (Marker)value;
@@ -24,11 +28,13 @@ namespace Bonsai.Aruco.Design
             }
         }
 
+        /// <inheritdoc/>
         public override void Load(IServiceProvider provider)
         {
             visualizer = (IplImageVisualizer)provider.GetService(typeof(MashupVisualizer));
         }
 
+        /// <inheritdoc/>
         public override void Unload()
         {
         }

--- a/src/Bonsai.Aruco.Design/MarkerVisualizer.cs
+++ b/src/Bonsai.Aruco.Design/MarkerVisualizer.cs
@@ -1,4 +1,4 @@
-﻿using Aruco.Net;
+using Aruco.Net;
 using Bonsai;
 using Bonsai.Aruco.Design;
 using Bonsai.Design;
@@ -7,6 +7,9 @@ using Bonsai.Design;
 
 namespace Bonsai.Aruco.Design
 {
+    /// <summary>
+    /// Provides a type visualizer that displays a textual representation of a <see cref="Marker"/>.
+    /// </summary>
     public class MarkerVisualizer : ObjectTextVisualizer
     {
     }

--- a/src/Bonsai.Aruco/DetectMarkers.cs
+++ b/src/Bonsai.Aruco/DetectMarkers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using OpenCV.Net;
 using Aruco.Net;
@@ -8,9 +8,15 @@ using System.IO;
 
 namespace Bonsai.Aruco
 {
+    /// <summary>
+    /// Represents an operator that detects planar fiducial markers in the input image sequence.
+    /// </summary>
     [Description("Detects planar fiducial markers in the input image sequence.")]
     public class DetectMarkers : Transform<IplImage, MarkerFrame>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DetectMarkers"/> class.
+        /// </summary>
         public DetectMarkers()
         {
             Param1 = 7.0;
@@ -22,35 +28,70 @@ namespace Bonsai.Aruco
             MarkerSize = 10;
         }
 
+        /// <summary>
+        /// Gets or sets the name of the YAML file storing the camera calibration parameters.
+        /// </summary>
         [FileNameFilter("YAML Files (*.yml)|*.yml|All Files (*.*)|*.*")]
         [Description("The name of the YAML file storing the camera calibration parameters.")]
         [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
         public string CameraParameters { get; set; }
 
+        /// <summary>
+        /// Gets or sets the threshold method used for marker detection.
+        /// </summary>
         [Description("The threshold method used for marker detection.")]
         public ThresholdMethod ThresholdMethod { get; set; }
 
+        /// <summary>
+        /// Gets or sets the first parameter of the threshold method.
+        /// </summary>
         [Description("The first parameter of the threshold method.")]
         public double Param1 { get; set; }
 
+        /// <summary>
+        /// Gets or sets the second parameter of the threshold method.
+        /// </summary>
         [Description("The second parameter of the threshold method.")]
         public double Param2 { get; set; }
 
+        /// <summary>
+        /// Gets or sets the minimum marker size as a fraction of the image size.
+        /// </summary>
         [Description("The minimum marker size as a fraction of the image size.")]
         public float MinSize { get; set; }
 
+        /// <summary>
+        /// Gets or sets the maximum marker size as a fraction of the image size.
+        /// </summary>
         [Description("The maximum marker size as a fraction of the image size.")]
         public float MaxSize { get; set; }
 
+        /// <summary>
+        /// Gets or sets the method used to refine marker corners.
+        /// </summary>
         [Description("The method used to refine marker corners.")]
         public CornerRefinementMethod CornerRefinement { get; set; }
 
+        /// <summary>
+        /// Gets or sets the size of the marker sides, in meters.
+        /// </summary>
         [Description("The size of the marker sides, in meters.")]
         public float MarkerSize { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to use the Y axis as the marker normal.
+        /// </summary>
         [Description("True to use the Y axis as the marker normal; otherwise the Z axis is used.")]
         public bool SetYPerpendicular { get; set; }
 
+        /// <summary>
+        /// Detects planar fiducial markers in an observable sequence of images.
+        /// </summary>
+        /// <param name="source">The sequence of images to scan for markers.</param>
+        /// <returns>
+        /// A sequence of <see cref="MarkerFrame"/> values containing the markers
+        /// detected in each input image.
+        /// </returns>
         public override IObservable<MarkerFrame> Process(IObservable<IplImage> source)
         {
             return Observable.Using(

--- a/src/Bonsai.Aruco/MarkerFrame.cs
+++ b/src/Bonsai.Aruco/MarkerFrame.cs
@@ -1,18 +1,35 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Aruco.Net;
 
 namespace Bonsai.Aruco
 {
+    /// <summary>
+    /// Represents the markers detected in an image, together with the associated camera parameters.
+    /// </summary>
     public class MarkerFrame
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarkerFrame"/> class with the specified
+        /// camera parameters and detected markers.
+        /// </summary>
+        /// <param name="cameraParameters">
+        /// The camera parameters, or <see langword="null"/> if no calibration was provided.
+        /// </param>
+        /// <param name="detectedMarkers">The markers detected in the image.</param>
         public MarkerFrame(CameraParameters cameraParameters, IList<Marker> detectedMarkers)
         {
             CameraParameters = cameraParameters;
             DetectedMarkers = detectedMarkers;
         }
 
+        /// <summary>
+        /// Gets the camera parameters, or <see langword="null"/> if no calibration was provided.
+        /// </summary>
         public CameraParameters CameraParameters { get; private set; }
 
+        /// <summary>
+        /// Gets the markers detected in the image.
+        /// </summary>
         public IList<Marker> DetectedMarkers { get; private set; }
     }
 }

--- a/src/Bonsai.Aruco/MarkerViewMatrix.cs
+++ b/src/Bonsai.Aruco/MarkerViewMatrix.cs
@@ -1,4 +1,4 @@
-﻿using Aruco.Net;
+using Aruco.Net;
 using OpenTK;
 using System;
 using System.ComponentModel;
@@ -7,9 +7,21 @@ using System.Reactive.Linq;
 
 namespace Bonsai.Aruco
 {
+    /// <summary>
+    /// Represents an operator that returns the modelview matrix given the extrinsic
+    /// parameters of the specified input marker.
+    /// </summary>
     [Description("Returns the modelview matrix given the extrinsic parameters of the specified input marker.")]
     public class MarkerViewMatrix : Transform<Marker, Matrix4>
     {
+        /// <summary>
+        /// Computes the modelview matrix from the extrinsic parameters of each input marker.
+        /// </summary>
+        /// <param name="source">The sequence of markers to convert.</param>
+        /// <returns>
+        /// A sequence of <see cref="Matrix4"/> values containing the modelview matrix for
+        /// each input marker, or the default value when the input marker is not valid.
+        /// </returns>
         public override IObservable<Matrix4> Process(IObservable<Marker> source)
         {
             return source.Select(input =>

--- a/src/Bonsai.Aruco/SelectMarker.cs
+++ b/src/Bonsai.Aruco/SelectMarker.cs
@@ -1,4 +1,4 @@
-﻿using Aruco.Net;
+using Aruco.Net;
 using System;
 using System.ComponentModel;
 using System.Linq;
@@ -6,12 +6,28 @@ using System.Reactive.Linq;
 
 namespace Bonsai.Aruco
 {
-    [Description("Selects the specified marker from the set of detected image markers, or an invalid marker if the marker is not detected.")]
+    /// <summary>
+    /// Represents an operator that selects the marker with the specified id from the input frame,
+    /// or an invalid marker if no match is found.
+    /// </summary>
+    [Description("Selects the marker with the specified id from the input frame, or an invalid marker if no match is found.")]
     public class SelectMarker : Transform<MarkerFrame, Marker>
     {
-        [Description("The id of the marker.")]
+        /// <summary>
+        /// Gets or sets the id of the marker to select.
+        /// </summary>
+        [Description("The id of the marker to select.")]
         public int Id { get; set; }
 
+        /// <summary>
+        /// Selects the marker with the specified <see cref="Id"/> from each input frame,
+        /// or returns an invalid marker if no match is found.
+        /// </summary>
+        /// <param name="source">The sequence of marker frames to filter.</param>
+        /// <returns>
+        /// A sequence of <see cref="Marker"/> values containing the selected marker from
+        /// each input frame, or <see cref="Marker.Empty"/> if no match is found.
+        /// </returns>
         public override IObservable<Marker> Process(IObservable<MarkerFrame> source)
         {
             return source.Select(input =>


### PR DESCRIPTION
Documents all public types across `Bonsai.Aruco` and `Bonsai.Aruco.Design` in preparation for release. The `MarkerFrame` data class and the three visualizer classes receive newly-authored summaries. The `DetectMarkersVisualizer` adds a brief `<remarks>` block flagging the right-click toggle between the original and thresholded image.